### PR TITLE
Protect scalar strings

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -132,14 +132,14 @@ SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg) {
           SEXP result = PROTECT(Rf_eval(call, R_GlobalEnv));
 
           str[j] = '\0';
-          out = set(out, out_idx, k++,
-                    Rf_ScalarString(Rf_mkCharLenCE(str, j, CE_UTF8)));
+          SEXP str_ = PROTECT(Rf_ScalarString(Rf_mkCharLenCE(str, j, CE_UTF8)));
+          out = set(out, out_idx, k++, str_);
           out = set(out, out_idx, k++, result);
 
           // Clear the string buffer
           memset(str, 0, j);
           j = 0;
-          UNPROTECT(3);
+          UNPROTECT(4);
           state = text;
 
           /* Move i to end of closing delim, but it always moves by 1 */

--- a/src/glue.c
+++ b/src/glue.c
@@ -151,8 +151,8 @@ SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg) {
   }
 
   str[j] = '\0';
-  out =
-      set(out, out_idx, k++, Rf_ScalarString(Rf_mkCharLenCE(str, j, CE_UTF8)));
+  SEXP str_ = PROTECT(Rf_ScalarString(Rf_mkCharLenCE(str, j, CE_UTF8)));
+  out = set(out, out_idx, k++, str_);
 
   if (state == delim) {
     Rf_error("Expecting '%s'", close);
@@ -160,6 +160,6 @@ SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg) {
 
   free(str);
 
-  UNPROTECT(1);
+  UNPROTECT(2);
   return out;
 }


### PR DESCRIPTION
Sorry I missed these in the first PR. This seems related to https://github.com/tidyverse/dplyr/pull/2877 which fixes protection errors on the dplyr side. Hope to converge to a stable solution eventually :-\