### PR TITLE
Fix tidyeval implementation

### DIFF
--- a/R/glue.R
+++ b/R/glue.R
@@ -61,7 +61,7 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(), .open = "{", 
   named <- have_name(args)
 
   if (is_env(.x)) {
-    overscope <- new_overscope(.x, top = empty_env(), enclosure = .x)
+    overscope <- new_overscope(.x, env_tail(.x), enclosure = .x)
   } else {
     bottom <- env_bury(empty_env(), !!! .x %||% list())
     overscope <- new_overscope(bottom, enclosure = .envir)

--- a/R/glue.R
+++ b/R/glue.R
@@ -47,7 +47,7 @@
 glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(), .open = "{", .close = "}") {
 
   args <- quos(...)
-  named <- has_names(args)
+  named <- have_name(args)
 
 
   data_src <- as_dictionary(.x, read_only = TRUE)

--- a/R/glue.R
+++ b/R/glue.R
@@ -2,18 +2,29 @@
 #'
 #' Expressions enclosed by braces will be evaluated as R code. Single braces
 #' can be inserted by doubling them.
-#' @param .x \[`listish`]\cr An environment, list or data frame used to lookup values.
-#' @param ... \[`expressions`]\cr Expressions string(s) to format, multiple inputs are concatenated together before formatting.
-#' @param .sep \[`character(1)`: \sQuote{""}]\cr Separator used to separate elements.
-#' @param .envir \[`environment`: `parent.frame()`]\cr Environment to evaluate each expression in. Expressions are
-#' evaluated from left to right. If `.x` is an environment, the expressions are
-#' evaluated in that environment and `.envir` is ignored.
-#' @param .open \[`character(1)`: \sQuote{\\\{}]\cr The opening delimiter. Doubling the
-#' full delimiter escapes it.
-#' @param .close \[`character(1)`: \sQuote{\\\}}]\cr The closing delimiter. Doubling the
-#' full delimiter escapes it.
+#' @param .x \[`listish`]\cr An environment, list or data frame used
+#'   to lookup values.
+#' @param ... \[`expressions`]\cr Expressions string(s) to format,
+#'   multiple inputs are concatenated together before formatting.
+#'   Strings are evaluated in `.envir` while expressions are evaluated
+#'   in their original context. Expressions are evaluated from left to
+#'   right.
+#' @param .sep \[`character(1)`: \sQuote{""}]\cr Separator used to
+#'   separate elements.
+#' @param .envir \[`environment`: `parent.frame()`]\cr Environment to
+#'   evaluate each string expression in. Symbolic expressions are
+#'   always evaluated in their original context. Note that tidyeval
+#'   idioms may be used to gain more control, e.g. unquoting a quosure
+#'   enclosed in a specific environment. If `.x` is an environment,
+#'   the expressions are evaluated in that environment and `.envir` is
+#'   ignored.
+#' @param .open \[`character(1)`: \sQuote{\\\{}]\cr The opening
+#'   delimiter. Doubling the full delimiter escapes it.
+#' @param .close \[`character(1)`: \sQuote{\\\}}]\cr The closing
+#'   delimiter. Doubling the full delimiter escapes it.
 #' @seealso <https://www.python.org/dev/peps/pep-0498/> and
-#' <https://www.python.org/dev/peps/pep-0257> upon which this is based.
+#'   <https://www.python.org/dev/peps/pep-0257> upon which this is
+#'   based.
 #' @examples
 #' name <- "Fred"
 #' age <- 50

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,12 +1,3 @@
-has_names <- function(x) {
-  nms <- names(x)
-  if (is.null(nms)) {
-    rep(FALSE, length(x))
-  } else {
-    !(is.na(nms) | nms == "")
-  }
-}
-
 # Use an explicit for loop rather than lapply to show evaluation order matters
 eval_args <- function(args, envir, data) {
   res <- vector("list", length(args))

--- a/man/glue.Rd
+++ b/man/glue.Rd
@@ -12,21 +12,31 @@ glue_data(.x, ..., .sep = "", .envir = parent.frame(), .open = "{",
 glue(..., .sep = "", .envir = parent.frame(), .open = "{", .close = "}")
 }
 \arguments{
-\item{.x}{[\code{listish}]\cr An environment, list or data frame used to lookup values.}
+\item{.x}{[\code{listish}]\cr An environment, list or data frame used
+to lookup values.}
 
-\item{...}{[\code{expressions}]\cr Expressions string(s) to format, multiple inputs are concatenated together before formatting.}
+\item{...}{[\code{expressions}]\cr Expressions string(s) to format,
+multiple inputs are concatenated together before formatting.
+Strings are evaluated in \code{.envir} while expressions are evaluated
+in their original context. Expressions are evaluated from left to
+right.}
 
-\item{.sep}{[\code{character(1)}: \sQuote{""}]\cr Separator used to separate elements.}
+\item{.sep}{[\code{character(1)}: \sQuote{""}]\cr Separator used to
+separate elements.}
 
-\item{.envir}{[\code{environment}: \code{parent.frame()}]\cr Environment to evaluate each expression in. Expressions are
-evaluated from left to right. If \code{.x} is an environment, the expressions are
-evaluated in that environment and \code{.envir} is ignored.}
+\item{.envir}{[\code{environment}: \code{parent.frame()}]\cr Environment to
+evaluate each string expression in. Symbolic expressions are
+always evaluated in their original context. Note that tidyeval
+idioms may be used to gain more control, e.g. unquoting a quosure
+enclosed in a specific environment. If \code{.x} is an environment,
+the expressions are evaluated in that environment and \code{.envir} is
+ignored.}
 
-\item{.open}{[\code{character(1)}: \sQuote{\{}]\cr The opening delimiter. Doubling the
-full delimiter escapes it.}
+\item{.open}{[\code{character(1)}: \sQuote{\{}]\cr The opening
+delimiter. Doubling the full delimiter escapes it.}
 
-\item{.close}{[\code{character(1)}: \sQuote{\}}]\cr The closing delimiter. Doubling the
-full delimiter escapes it.}
+\item{.close}{[\code{character(1)}: \sQuote{\}}]\cr The closing
+delimiter. Doubling the full delimiter escapes it.}
 }
 \description{
 Expressions enclosed by braces will be evaluated as R code. Single braces
@@ -61,5 +71,6 @@ glue("The value of $e^{2\\\\pi i}$ is $<<one>>$.", .open = "<<", .close = ">>")
 }
 \seealso{
 \url{https://www.python.org/dev/peps/pep-0498/} and
-\url{https://www.python.org/dev/peps/pep-0257} upon which this is based.
+\url{https://www.python.org/dev/peps/pep-0257} upon which this is
+based.
 }

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -124,7 +124,7 @@ test_that("glue evaluates arguments in the expected environment", {
     glue("x: {x}, x+1: {y}", y = x + 1, .envir = parent.frame())
   }
 
-  expect_identical(as_glue("x: 2, x+1: 3"), fun())
+  expect_identical(as_glue("x: 2, x+1: 2"), fun())
 })
 
 test_that("glue assigns arguments in the environment", {


### PR DESCRIPTION
The semantics of glue need to change a bit to support tidyeval. Expressions must be evaluated in their original environment, i.e. `.envir` is ignored for expressions.

The alternative is to set the environments of captured quosures to `.envir`, but that would make for weird semantics. E.g. if a user unquotes a quosure in a top-level expression, her quosure environment will be overwritten as well. The following would print "FOO" instead of "foo":

```r
quo <- locally({
  foo <- "foo"
  quo(foo)
})

foo <- "FOO"
glue("{x}", x = !! quo)
```

I refilled the roxygen to a more conventional format while adjusting the documentation, let me know if you prefer the old format (which I find harder to read).