### PR TITLE
Keep bullets in the description

### DIFF
--- a/R/glue.R
+++ b/R/glue.R
@@ -149,11 +149,9 @@ collapse <- function(x, sep = "", width = Inf, last = "") {
 
 #' Trim a character vector
 #'
-#' @description
 #' This trims a character vector according to the trimming rules used by glue.
 #' These follow similar rules to [Python Docstrings](https://www.python.org/dev/peps/pep-0257),
 #' with the following features.
-#'
 #' - Leading and trailing whitespace from the first and last lines is removed.
 #' - A uniform amount of indentation is stripped from the second line on, equal
 #' to the minimum indentation of all non-blank lines after the first.

--- a/R/glue.R
+++ b/R/glue.R
@@ -149,6 +149,7 @@ collapse <- function(x, sep = "", width = Inf, last = "") {
 
 #' Trim a character vector
 #'
+#' @description
 #' This trims a character vector according to the trimming rules used by glue.
 #' These follow similar rules to [Python Docstrings](https://www.python.org/dev/peps/pep-0257),
 #' with the following features.

--- a/man/trim.Rd
+++ b/man/trim.Rd
@@ -13,8 +13,6 @@ trim(x)
 This trims a character vector according to the trimming rules used by glue.
 These follow similar rules to \href{https://www.python.org/dev/peps/pep-0257}{Python Docstrings},
 with the following features.
-}
-\details{
 \itemize{
 \item Leading and trailing whitespace from the first and last lines is removed.
 \item A uniform amount of indentation is stripped from the second line on, equal


### PR DESCRIPTION
There's a thing with the markdown syntax and bullet lists.

https://github.com/jeroen/commonmark/issues/7