### PR TITLE
Update README with better install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Installation
 ------------
 
 ``` r
+# Install the released version from CRAN:
+install.packages("glue")
+
+# Or the development version from GitHub:
 # install.packages("devtools")
 devtools::install_github("tidyverse/glue")
 ```


### PR DESCRIPTION
Update README so that stable CRAN install instructions are included before development version