### PR TITLE
Change glue_sql_data() to glue_data_sql()

### DIFF
--- a/R/sql.R
+++ b/R/sql.R
@@ -2,7 +2,7 @@
 #'
 #' SQL databases often have custom quotation syntax for identifiers and strings
 #' which make writing SQL queries error prone and cumbersome to do. `glue_sql()` and
-#' `glue_sql_data()` are analogs to `glue()` and `glue_data()` which handle the
+#' `glue_data_sql()` are analogs to `glue()` and `glue_data()` which handle the
 #' SQL quoting.
 #'
 #' They automatically quote character results, quote identifiers if the glue

--- a/man/glue_sql.Rd
+++ b/man/glue_sql.Rd
@@ -31,7 +31,7 @@ A \code{DBI::SQL()} object with the given query.
 \description{
 SQL databases often have custom quotation syntax for identifiers and strings
 which make writing SQL queries error prone and cumbersome to do. \code{glue_sql()} and
-\code{glue_sql_data()} are analogs to \code{glue()} and \code{glue_data()} which handle the
+\code{glue_data_sql()} are analogs to \code{glue()} and \code{glue_data()} which handle the
 SQL quoting.
 }
 \details{

--- a/vignettes/releases/glue-1.2.0.Rmd
+++ b/vignettes/releases/glue-1.2.0.Rmd
@@ -122,7 +122,7 @@ glue_fmt("π = {pi%.5f}")
 
 ## glue_sql()
 
-Also new to glue 1.2.0 is `glue_sql()` and `glue_sql_data()`, which are helper
+Also new to glue 1.2.0 is `glue_sql()` and `glue_data_sql()`, which are helper
 functions defined with glue transformers to make it easy and safe to construct
 SQL statements.
 


### PR DESCRIPTION
Changed the mentions of `glue_sql_data()` in the documentation to `glue_data_sql()` (since that's the exported function).
* n.b. only ran `devtools::document()` and built the relevant vignette, as I didn't want to mess up the pkgdown site.