### PR TITLE
should trim \t as well

### DIFF
--- a/R/glue.R
+++ b/R/glue.R
@@ -190,7 +190,7 @@ collapse <- function(x, sep = "", width = Inf, last = "") {
 
 #' @useDynLib glue trim_
 trim <- function(x) {
-  has_newline <- function(x) grepl("\\n", x)
+  has_newline <- function(x) grepl("(\\n|\\t)", x)
   if (length(x) == 0 || !has_newline(x)) {
     return(x)
   }

--- a/src/trim.c
+++ b/src/trim.c
@@ -97,6 +97,7 @@ SEXP trim_(SEXP x) {
       } else if (str[j] == '\0' || str[j] == ' ' || str[j] == '\t') {
         --j;
       } else {
+        end = j + 1;
         break;
       }
     }

--- a/tests/testthat/test-trim.R
+++ b/tests/testthat/test-trim.R
@@ -18,7 +18,7 @@ test_that("trim works", {
       "test
     "))
   expect_identical("test",
-    trim("      
+    trim("
       test
       "))
   expect_identical("test",
@@ -114,4 +114,8 @@ test_that("issue#47", {
          The stuff before the bullet list
            * one bullet
          "), expected)
+  expect_identical(trim("\tabc"), "abc")
+  expect_identical(trim("\nabc"), "abc")
+  expect_identical(trim("\nabc\t"), "abc")
+  expect_identical(trim("abc\t"), "abc")
 })


### PR DESCRIPTION
Not sure if it's intended or not but the current behavior seems quite awkward for me...

I also tried to include `" "` space as well but see these tests... If the behavior is very different from what people already know (a.k.a `stringr::str_trim()`), maybe a better name?

```r
expect_identical(" ", trim(" "))
expect_identical("test", trim("test"))
expect_identical(" test", trim(" test"))
expect_identical("test ", trim("test "))
``` 