### PR TITLE
Fix glue encoding

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Do not drop the `glue` class when subsetting (#66).
 
+* Fix `glue()` and `collapse()` always return UTF-8 encoded strings (#81, @dpprdan)
+
 # glue 1.2.0
 
 * The implementation has been tweaked to be slightly faster in most cases.

--- a/R/glue.R
+++ b/R/glue.R
@@ -111,6 +111,8 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(), .open = "{", 
     res <- replace(res, na_rows, NA)
   }
 
+  res <- enc2utf8(res)
+
   as_glue(res)
 }
 

--- a/R/glue.R
+++ b/R/glue.R
@@ -159,6 +159,7 @@ collapse <- function(x, sep = "", width = Inf, last = "") {
       x <- paste0(substr(x, 1, width - 3), "...")
     }
   }
+  x <- enc2utf8(x)
   as_glue(x)
 }
 

--- a/R/glue.R
+++ b/R/glue.R
@@ -111,8 +111,6 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(), .open = "{", 
     res <- replace(res, na_rows, NA)
   }
 
-  res <- enc2utf8(res)
-
   as_glue(res)
 }
 
@@ -159,7 +157,6 @@ collapse <- function(x, sep = "", width = Inf, last = "") {
       x <- paste0(substr(x, 1, width - 3), "...")
     }
   }
-  x <- enc2utf8(x)
   as_glue(x)
 }
 

--- a/R/glue.R
+++ b/R/glue.R
@@ -227,7 +227,7 @@ as_glue.glue <- function(x, ...) {
 #' @export
 as_glue.character <- function(x, ...) {
   class(x) <- c("glue", "character")
-  x
+  enc2utf8(x)
 }
 
 #' @export

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -233,6 +233,8 @@ test_that("glue always returns UTF-8 encoded strings regardless of input encodin
 
   expect_identical(x_out, glue(x))
   expect_identical(x_out, glue("{x}"))
+  expect_equal(Encoding(glue(x)), "UTF-8")
+  expect_equal(Encoding(glue("{x}")), "UTF-8")
 
   y <- "p\u00E4o"
   Encoding(y) <- "UTF-8"
@@ -241,11 +243,17 @@ test_that("glue always returns UTF-8 encoded strings regardless of input encodin
 
   expect_identical(y_out, glue(y))
   expect_identical(y_out, glue("{y}"))
+  expect_equal(Encoding(glue(y)), "UTF-8")
+  expect_equal(Encoding(glue("{y}")), "UTF-8")
 
   xy_out <- as_glue(paste0(x_out, y_out))
 
   expect_identical(xy_out, glue(x, y))
   expect_identical(xy_out, glue("{x}{y}"))
+  expect_equal(Encoding(glue(x, y)), "UTF-8")
+  expect_equal(Encoding(glue("{x}{y}")), "UTF-8")
+
+  expect_equal(Encoding(collapse(x)), "UTF-8")
 })
 
 test_that("glue always returns NA_character_ if given any NA input and `.na` == NULL", {

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -231,23 +231,21 @@ test_that("glue always returns UTF-8 encoded strings regardless of input encodin
 
   x_out <- as_glue(enc2utf8(x))
 
-  expect_identical(Encoding(x_out), Encoding(glue(x)))
-  expect_identical(Encoding(x_out), Encoding(glue("{x}")))
+  expect_identical(x_out, glue(x))
+  expect_identical(x_out, glue("{x}"))
 
   y <- "p\u00E4o"
   Encoding(y) <- "UTF-8"
 
   y_out <- as_glue(enc2utf8(y))
 
-  expect_identical(Encoding(y_out), Encoding(glue(y)))
-  expect_identical(Encoding(y_out), Encoding(glue("{y}")))
+  expect_identical(y_out, glue(y))
+  expect_identical(y_out, glue("{y}"))
 
   xy_out <- as_glue(paste0(x_out, y_out))
 
-  expect_identical(Encoding(xy_out), Encoding(glue(x, y)))
-  expect_identical(Encoding(xy_out), Encoding(glue("{x}{y}")))
-
-  expect_identical(Encoding(x_out), Encoding(collapse(x)))
+  expect_identical(xy_out, glue(x, y))
+  expect_identical(xy_out, glue("{x}{y}"))
 })
 
 test_that("glue always returns NA_character_ if given any NA input and `.na` == NULL", {

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -231,21 +231,21 @@ test_that("glue always returns UTF-8 encoded strings regardless of input encodin
 
   x_out <- as_glue(enc2utf8(x))
 
-  expect_identical(x_out, glue(x))
-  expect_identical(x_out, glue("{x}"))
+  expect_identical(Encoding(x_out), Encoding(glue(x)))
+  expect_identical(Encoding(x_out), Encoding(glue("{x}")))
 
   y <- "p\u00E4o"
   Encoding(y) <- "UTF-8"
 
   y_out <- as_glue(enc2utf8(y))
 
-  expect_identical(y_out, glue(y))
-  expect_identical(y_out, glue("{y}"))
+  expect_identical(Encoding(y_out), Encoding(glue(y)))
+  expect_identical(Encoding(y_out), Encoding(glue("{y}")))
 
   xy_out <- as_glue(paste0(x_out, y_out))
 
-  expect_identical(xy_out, glue(x, y))
-  expect_identical(xy_out, glue("{x}{y}"))
+  expect_identical(Encoding(xy_out), Encoding(glue(x, y)))
+  expect_identical(Encoding(xy_out), Encoding(glue("{x}{y}")))
 })
 
 test_that("glue always returns NA_character_ if given any NA input and `.na` == NULL", {

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -246,6 +246,8 @@ test_that("glue always returns UTF-8 encoded strings regardless of input encodin
 
   expect_identical(Encoding(xy_out), Encoding(glue(x, y)))
   expect_identical(Encoding(xy_out), Encoding(glue("{x}{y}")))
+
+  expect_identical(Encoding(x_out), Encoding(collapse(x)))
 })
 
 test_that("glue always returns NA_character_ if given any NA input and `.na` == NULL", {


### PR DESCRIPTION
`glue()` does not always return UTF-8 encoded strings

```r
a <- "ä"
Encoding(glue("{a}"))
#> [1] "latin1"
```

"That is strange, because there is even a [test](https://github.com/tidyverse/glue/blob/master/tests/testthat/test-glue.R#L228) for that", you might think. Well, that test does not actually test for identical encodings, because `identical()` and by extension `expect_identical()` do not care about encodings. 

``` r
x <- "fa\xE7ile"
Encoding(x) <- "latin1"
identical(x, enc2utf8(x))
#> [1] TRUE
```

So I fixed the test by explicitly testing for `Encoding()` and added `enc2utf8()` to both `glue()` and `collapse()`.