### PR TITLE
Lazily evaluate named interpolation variables

### DIFF
--- a/R/glue.R
+++ b/R/glue.R
@@ -73,7 +73,7 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(), .open = "{", 
   named <- has_names(dots)
 
   # Capture named arguments as promises, in order
-  env <- bind_ordered_promises(dots[named], parent)
+  env <- bind_promises(dots[named], parent)
 
   # Concatenate unnamed arguments together
   unnamed_args <- lapply(which(!named), function(x) eval(call("force", as.symbol(paste0("..", x)))))

--- a/R/glue.R
+++ b/R/glue.R
@@ -79,7 +79,7 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(), .open = "{", 
   unnamed_args <- lapply(which(!named), function(x) eval(call("force", as.symbol(paste0("..", x)))))
 
   lengths <- lengths(unnamed_args)
-  if (any(lengths == 0) || length(unnamed_args) < length(dots[!named])) {
+  if (any(lengths == 0) || length(unnamed_args) < sum(!named)) {
     return(as_glue(character(0)))
   }
   if (any(lengths != 1)) {

--- a/R/glue.R
+++ b/R/glue.R
@@ -61,19 +61,19 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(), .open = "{", 
 
   # Perform all evaluations in a temporary environment
   if (is.null(.x)) {
-    env <- new.env(parent = .envir)
+    parent <- .envir
   } else if (is.environment(.x)) {
-    env <- new.env(parent = .x)
+    parent <- .x
   } else {
-    env <- list2env(.x, parent = .envir)
+    parent <- list2env(.x, parent = .envir)
   }
 
   # Capture unevaluated arguments
   dots <- eval(substitute(alist(...)))
   named <- has_names(dots)
 
-  # Evaluate named arguments, add results to environment
-  assign_args(dots[named], env)
+  # Capture named arguments as promises, in order
+  env <- bind_ordered_promises(dots[named], parent)
 
   # Concatenate unnamed arguments together
   unnamed_args <- lapply(which(!named), function(x) eval(call("force", as.symbol(paste0("..", x)))))

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,10 +7,10 @@ has_names <- function(x) {
   }
 }
 
-bind_promises <- function(args, parent) {
+bind_promises <- function(exprs, parent) {
   env <- env_init <- new.env(parent = baseenv())
-  for (i in seq_along(args))
-    env <- as_promise(.subset(args, i), env)
+  for (i in seq_along(exprs))
+    env <- as_promise(.subset(exprs, i), env)
   # Must rechain initial parent environment, rather than creating the
   # promise-making function in 'parent', because 'parent' need not have 'base'
   # as ancestor.
@@ -18,12 +18,9 @@ bind_promises <- function(args, parent) {
   env
 }
 
-as_promise <- function(arg, env) {
-  make_promise <- as.call(c(
-    call("function", as.pairlist(arg), quote(environment())),
-    arg
-  ))
-  eval(make_promise, env)
+as_promise <- function(expr, env) {
+  promise <- call("function", as.pairlist(expr), quote(environment()))
+  eval(as.call(c(promise, expr)), env)
 }
 
 # From tibble::recycle_columns

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,14 +7,18 @@ has_names <- function(x) {
   }
 }
 
-bind_ordered_promises <- function(args, parent) {
-  env_assign <- parent
-  for (nm in names(args)) {
-    env_eval <- env_assign
-    env_assign <- new.env(parent = env_assign)
-    eval(bquote(delayedAssign(nm, .(args[[nm]]), env_eval, env_assign)))
-  }
-  env_assign
+bind_promises <- function(args, parent) {
+  promises <- as_promises(args)
+
+  # Must rechain parent environment, rather than creating the promise-making
+  # function in 'parent', because 'parent' need not have 'base' as ancestor.
+  parent.env(promises) <- parent
+
+  promises
+}
+
+as_promises <- function(args) {
+  eval(call("function", as.pairlist(args), quote(environment())))()
 }
 
 # From tibble::recycle_columns

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,12 +7,14 @@ has_names <- function(x) {
   }
 }
 
-assign_args <- function(args, envir) {
-  res <- vector("list", length(args))
-  nms <- names(args)
-  for (i in seq_along(args)) {
-    assign(nms[[i]], eval(args[[i]], envir), envir = envir)
+bind_ordered_promises <- function(args, parent) {
+  env_assign <- parent
+  for (nm in names(args)) {
+    env_eval <- env_assign
+    env_assign <- new.env(parent = env_assign)
+    eval(bquote(delayedAssign(nm, .(args[[nm]]), env_eval, env_assign)))
   }
+  env_assign
 }
 
 # From tibble::recycle_columns

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -169,6 +169,31 @@ test_that("glue_data evaluates in the object first, then enclosure, then parent"
   expect_identical(as_glue("3 3 3"), glue_data(env2, "{x} {y} {z}"))
 })
 
+test_that("glue_data lazily evaluates named interpolation variables", {
+  # Decoy 'x', which should not be evaluated
+  delayedAssign("x", stop("!"))
+
+  env <- new.env()
+  env$x <- "blah"
+
+  expect_identical(
+    glue_data(.x = env, "{x}{z}", y = stop("!"), z = x),
+    as_glue("blahblah")
+  )
+  expect_identical(
+    glue_data(.x = list(x = "blah"), "{x}{z}", y = stop("!"), z = x),
+    as_glue("blahblah")
+  )
+  expect_identical(
+    glue_data(.x = NULL, "{x}{z}", x = "blah", y = stop("!"), z = x),
+    as_glue("blahblah")
+  )
+  expect_identical(
+    glue_data(.x = NULL, "blahblah", y = stop("!"), z = x),
+    as_glue("blahblah")
+  )
+})
+
 test_that("converting glue to character", {
   expect_identical("foo bar", as.character(glue("foo bar")))
 })


### PR DESCRIPTION
_A priori_, an interpolation string need not reference every variable supplied as a named dot-argument of `glue_data()`, so there is no need to evaluate them eagerly. In particular, `glue("{x}", x = "blah", y = {Sys.sleep(1); "y"})` ought to be as fast as `glue("{x}", x = "blah")`, and `glue("blah", x = stop("!"))` should also yield `as_glue("blah")`.

This PR implements (ordered) lazy evaluation of named interpolation variables.

If this is desirable, a review would be appreciated.
Thanks for your consideration.