### PR TITLE
Interpolation variables can have same names as their values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,9 @@
 
 * Glue now evaluates unnamed arguments lazily with `delayedAssign()`, so there
   is no performance cost if an argument is not used. (#83, @egnha).
+  
+* Fixed a bug where names in the assigned expression of an interpolation
+  variable would conflict with the name of the variable itself (#89, @egnha).
 
 * `glue_col()` and `glue_data_col()` functions to display strings with color.
 

--- a/R/glue.R
+++ b/R/glue.R
@@ -65,11 +65,11 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
 
   # Perform all evaluations in a temporary environment
   if (is.null(.x)) {
-    env <- new.env(parent = .envir)
+    parent <- .envir
   } else if (is.environment(.x)) {
-    env <- new.env(parent = .x)
+    parent <- .x
   } else {
-    env <- list2env(.x, parent = .envir)
+    parent <- list2env(.x, parent = .envir)
   }
 
   # Capture unevaluated arguments
@@ -77,7 +77,7 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
   named <- has_names(dots)
 
   # Evaluate named arguments, add results to environment
-  assign_args(dots[named], env)
+  env <- bind_args(dots[named], parent)
 
   # Concatenate unnamed arguments together
   unnamed_args <- lapply(which(!named), function(x) eval(call("force", as.symbol(paste0("..", x)))))

--- a/R/glue.R
+++ b/R/glue.R
@@ -65,11 +65,11 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
 
   # Perform all evaluations in a temporary environment
   if (is.null(.x)) {
-    parent <- .envir
+    parent_env <- .envir
   } else if (is.environment(.x)) {
-    parent <- .x
+    parent_env <- .x
   } else {
-    parent <- list2env(.x, parent = .envir)
+    parent_env <- list2env(.x, parent = .envir)
   }
 
   # Capture unevaluated arguments
@@ -77,7 +77,7 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
   named <- has_names(dots)
 
   # Evaluate named arguments, add results to environment
-  env <- bind_args(dots[named], parent)
+  env <- bind_args(dots[named], parent_env)
 
   # Concatenate unnamed arguments together
   unnamed_args <- lapply(which(!named), function(x) eval(call("force", as.symbol(paste0("..", x)))))

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,14 +8,14 @@ has_names <- function(x) {
 }
 
 bind_args <- function(args, parent) {
-  env_assign <- parent
+  assign_env <- parent
   nms <- names(args)
   for (i in seq_along(args)) {
-    env_eval <- env_assign
-    env_assign <- new.env(parent = env_eval)
-    delayed_assign(nms[[i]], args[[i]], eval.env = env_eval, assign.env = env_assign)
+    eval_env <- assign_env
+    assign_env <- new.env(parent = eval_env)
+    delayed_assign(nms[[i]], args[[i]], eval.env = eval_env, assign.env = assign_env)
   }
-  env_assign
+  assign_env
 }
 
 # From tibble::recycle_columns

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,11 +7,15 @@ has_names <- function(x) {
   }
 }
 
-assign_args <- function(args, envir) {
+bind_args <- function(args, parent) {
+  env_assign <- parent
   nms <- names(args)
   for (i in seq_along(args)) {
-    delayed_assign(nms[[i]], args[[i]], eval.env = envir, assign.env = envir)
+    env_eval <- env_assign
+    env_assign <- new.env(parent = env_eval)
+    delayed_assign(nms[[i]], args[[i]], eval.env = env_eval, assign.env = env_assign)
   }
+  env_assign
 }
 
 # From tibble::recycle_columns

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -386,18 +386,8 @@ test_that("glue does not drop it's class when subsetting", {
 })
 
 test_that("interpolation variables can have same names as their values (#89)", {
-  name <- "Joe"
-  age <- 40
-  anniversary <- as.Date("2001-10-12")
+  x <- 1
   expect_identical(
-    glue(
-      'Name: {name};',
-      ' age: {age + 1};',
-      ' anniversary: {format(anniversary, "%A, %B %d, %Y")}.',
-      name = name,
-      age = age,
-      anniversary = anniversary
-    ),
-    as_glue("Name: Joe; age: 41; anniversary: Friday, October 12, 2001.")
-  )
+    glue("{x}", x = x + 1),
+    as_glue("2"))
 })

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -384,3 +384,20 @@ test_that("glue does not drop it's class when subsetting", {
   expect_identical(
     glue("{1:2}")[2], as_glue("2"))
 })
+
+test_that("interpolation variables can have same names as their values (#89)", {
+  name <- "Joe"
+  age <- 40
+  anniversary <- as.Date("2001-10-12")
+  expect_identical(
+    glue(
+      'Name: {name};',
+      ' age: {age + 1};',
+      ' anniversary: {format(anniversary, "%A, %B %d, %Y")}.',
+      name = name,
+      age = age,
+      anniversary = anniversary
+    ),
+    as_glue("Name: Joe; age: 41; anniversary: Friday, October 12, 2001.")
+  )
+})


### PR DESCRIPTION
Since the expected behavior of `glue_date()` is to lazily evaluate the interpolation variables from left to right, we need to do sequenced look-up (of promises) through a chain of environments.

Fixes #89.