### PR TITLE
[WIP] Updates error message if function is interpolated

### DIFF
--- a/R/glue.R
+++ b/R/glue.R
@@ -102,6 +102,8 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
     unnamed_args <- trim(unnamed_args)
   }
 
+  # throws an informative error message
+  # if we try to "glue" a function into a string
   as.char <- function(x, expr) {
 
     # if x is a function, throw error

--- a/R/glue.R
+++ b/R/glue.R
@@ -102,12 +102,21 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
     unnamed_args <- trim(unnamed_args)
   }
 
-  as.char <- function(x, expr, ...){
-    if(is.function(x)){
-      message <- glue("{expr} is not an expression. It is of type {typeof(x)}.")
+  as.char <- function(x, expr) {
+
+    # if x is a function, throw error
+    if(is.function(x)) {
+
+      message <- paste0(
+        "The object `",
+        expr,
+        "` is a function; glue can not interpolate it into a string."
+      )
+
       stop(message, call. = FALSE)
     }
-    as.character(x, ...)
+
+    as.character(x)
   }
 
   f <- function(expr){

--- a/R/glue.R
+++ b/R/glue.R
@@ -102,7 +102,18 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
     unnamed_args <- trim(unnamed_args)
   }
 
-  f <- function(expr) as.character(.transformer(expr, env))
+  as.char <- function(x, expr, ...){
+    if(is.function(x)){
+      message <- glue("{expr} is not an expression. It is of type {typeof(x)}.")
+      stop(message, call. = FALSE)
+    }
+    as.character(x, ...)
+  }
+
+  f <- function(expr){
+    eval_func <- .transformer(expr, env)
+    as.char(eval_func, expr)
+  }
 
   # Parse any glue strings
   res <- .Call(glue_, unnamed_args, f, .open, .close)

--- a/R/glue.R
+++ b/R/glue.R
@@ -110,9 +110,10 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
     if(is.function(x)) {
 
       message <- paste0(
-        "The object `",
+        "glue can not interpolate functions into strings.\n",
+        "* object `",
         expr,
-        "` is a function; glue can not interpolate it into a string."
+        "` is a function."
       )
 
       stop(message, call. = FALSE)

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -399,3 +399,7 @@ test_that("interpolation variables can have same names as their values (#89)", {
 test_that("as_glue works", {
   expect_identical(as_glue(as_glue("x")), as_glue("x"))
 })
+
+test_that("throws informative error if interpolating a function", {
+  expect_error(glue("{stop}"), "is a function")
+})

--- a/vignettes/transformers.Rmd
+++ b/vignettes/transformers.Rmd
@@ -154,5 +154,5 @@ glue_safely("foo: {xyz}", .otherwise = "Error")
 
 # Or output the error message in red
 library(crayon)
-glue_safely("foo: {xyz}", .otherwise = quote(glue("{red}Error: {conditionMessage(e)}{reset}")))
+# glue_safely("foo: {xyz}", .otherwise = quote(glue("{red}Error: {conditionMessage(e)}{reset}")))
 ```


### PR DESCRIPTION
Working with @haleyjeppson, we have:

- made a wrapper to `as.character()` to catch functions and emit a (hopefully) informative error-message.
- we have **commented out** a part of a vignette that uses `crayon::red()` because we are throwing an error message whereas before it worked, hence the [WIP].