### PR TITLE
`glue_sql()` now collapses zero-length vector into `DBI::SQL("NULL")`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Features
 
 * `glue()` now has a `+` method to combine strings.
+* `glue_sql()` now collapses zero-length vector into `DBI::SQL("NULL")` (#134 @shrektan).
 
 ## Bugfixes and minor changes
 

--- a/R/sql.R
+++ b/R/sql.R
@@ -144,6 +144,9 @@ sql_quote_transformer <- function(connection) {
     if (should_collapse) {
       res <- glue_collapse(res, ", ")
     }
+    if (length(res) == 0L) {
+      res <- DBI::SQL("NULL")
+    }
     res
   }
 }

--- a/tests/testthat/test-sql.R
+++ b/tests/testthat/test-sql.R
@@ -48,6 +48,9 @@ describe("glue_sql", {
     expect_identical(glue_sql("{var*}", .con = con, var = "a"), DBI::SQL("'a'"))
     expect_identical(glue_sql("{var*}", .con = con, var = letters[1:5]), DBI::SQL("'a', 'b', 'c', 'd', 'e'"))
   })
+  it('collapses values should return NULL for length zero vector', {
+    expect_identical(glue_sql("{var*}", .con = con, var = character()), DBI::SQL("NULL"))
+  })
   it("should return an SQL NULL by default for missing values", {
     var <- list(NA, NA_character_, NA_real_, NA_integer_)
     expect_identical(glue_sql("x = {var}", .con = con), rep(DBI::SQL("x = NULL"), 4))


### PR DESCRIPTION
Closes #133

### Example Code

```r
con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")
sql <- 'select * from tbl where values in ({v*})'
v <- character()
glue_sql(sql, .con = con)
```

* Before it returns an empty SQL: `<SQL>`
* Now it returns a valid SQL: `<SQL> select * from tbl where values in (NULL)`