### PR TITLE
Tweak collapse transformer

### DIFF
--- a/vignettes/transformers.Rmd
+++ b/vignettes/transformers.Rmd
@@ -33,8 +33,11 @@ aim right now is not to include most of these custom functions within the
 transformers to fit their individual needs.
 
 ```{r, include = FALSE}
-library(glue)
 knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+```
+
+```{r}
+library(glue)
 ```
 
 ### collapse transformer

--- a/vignettes/transformers.Rmd
+++ b/vignettes/transformers.Rmd
@@ -47,9 +47,10 @@ A transformer which automatically collapses any glue block ending with `*`.
 ```{r}
 collapse_transformer <- function(regex = "[*]$", ...) {
   function(text, envir) {
-    if (grepl(regex, text)) {
-        text <- sub(regex, "", text)
+    if (!grepl(regex, text)) {
+      return(eval(parse(text = text, keep.source = FALSE), envir = envir))
     }
+    text <- sub(regex, "", text)
     res <- eval(parse(text = text, keep.source = FALSE), envir)
     glue_collapse(res, ...)
   }
@@ -58,6 +59,9 @@ collapse_transformer <- function(regex = "[*]$", ...) {
 glue("{1:5*}\n{letters[1:5]*}", .transformer = collapse_transformer(sep = ", "))
 
 glue("{1:5*}\n{letters[1:5]*}", .transformer = collapse_transformer(sep = ", ", last = " and "))
+
+x <- c("one", "two")
+glue("{x}: {1:5*}", .transformer = collapse_transformer(sep = ", "))
 ```
 
 ### Shell quoting transformer

--- a/vignettes/transformers.Rmd
+++ b/vignettes/transformers.Rmd
@@ -47,12 +47,16 @@ A transformer which automatically collapses any glue block ending with `*`.
 ```{r}
 collapse_transformer <- function(regex = "[*]$", ...) {
   function(text, envir) {
-    if (!grepl(regex, text)) {
-      return(eval(parse(text = text, keep.source = FALSE), envir = envir))
+    collapse <- grepl(regex, text)
+    if (collapse) {
+      text <- sub(regex, "", text)
     }
-    text <- sub(regex, "", text)
-    res <- eval(parse(text = text, keep.source = FALSE), envir)
-    glue_collapse(res, ...)
+    res <- identity_transformer(text, envir)
+    if (collapse) {
+      glue_collapse(res, ...)  
+    } else {
+      res
+    }
   }
 }
 


### PR DESCRIPTION
I think the `collapse_transformer()` needs a fix. The original version applies the collapse transformation to all inputs, even if they lack the trailing `*`.

---

Before this PR:

``` r
library(glue)
collapse_transformer <- function(regex = "[*]$", ...) {
  function(text, envir) {
    if (grepl(regex, text)) {
        text <- sub(regex, "", text)
    }
    res <- eval(parse(text = text, keep.source = FALSE), envir)
    glue_collapse(res, ...)
  }
}

x <- c("one", "two")
glue("{x}: {1:5*}", .transformer = collapse_transformer(sep = ", "))
#> one, two: 1, 2, 3, 4, 5
```

---

After this PR:

``` r
library(glue)
collapse_transformer <- function(regex = "[*]$", ...) {
  function(text, envir) {
    if (!grepl(regex, text)) {
      return(eval(parse(text = text, keep.source = FALSE), envir = envir))
    }
    text <- sub(regex, "", text)
    res <- eval(parse(text = text, keep.source = FALSE), envir)
    glue_collapse(res, ...)
  }
}

x <- c("one", "two")
glue("{x}: {1:5*}", .transformer = collapse_transformer(sep = ", "))
#> one: 1, 2, 3, 4, 5
#> two: 1, 2, 3, 4, 5
```
