### PR TITLE
Adds tests for colored output with quotes and graves (Issue #158)

### DIFF
--- a/tests/testthat/test-color.R
+++ b/tests/testthat/test-color.R
@@ -29,6 +29,11 @@ describe("glue_col", {
     expect_identical(glue_col("{red This is a {green serious} problem}"),
       as_glue(red("This is a " %+% green("serious") %+% " problem")))
   })
+  it("works with single quotes, double quotes, graves", {
+    expect_identical(glue_col("{blue foo's}"), as_glue(blue("foo's")))
+    expect_identical(glue_col("{blue foo\"s}"), as_glue(blue("foo\"s")))
+    expect_identical(glue_col("{blue foo`s}"), as_glue(blue("foo`s")))
+  })
 
   it("errors if there is invalid syntax or fun is not found", {
     expect_error(glue_col("{_}"), "unexpected input")


### PR DESCRIPTION
New tests fail on my installs. Ref #158 

#### Fail record

```
==> devtools::test()

Loading glue
Testing glue
v | OK F W S | Context
v | 20       | glue_collapse
x | 12 3     | color
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test-color.R:33: failure: glue_col: works with single quotes, double quotes, graves
glue_col("{blue foo's}") not identical to as_glue(blue("foo's")).
1/1 mismatches
x[1]: ""
y[1]: "\033[34mfoo's\033[39m"

test-color.R:34: failure: glue_col: works with single quotes, double quotes, graves
glue_col("{blue foo\"s}") not identical to as_glue(blue("foo\"s")).
1/1 mismatches
x[1]: ""
y[1]: "\033[34mfoo\"s\033[39m"

test-color.R:35: failure: glue_col: works with single quotes, double quotes, graves
glue_col("{blue foo`s}") not identical to as_glue(blue("foo`s")).
1/1 mismatches
x[1]: ""
y[1]: "\033[34mfoo`s\033[39m"
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
v | 104       | glue [0.1 s]
v | 12       | quoting
v |  0     1 | sql
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test-sql.R:3: skip: (unknown)
DBI cannot be loaded
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
v | 27       | trim

== Results ===============================================================================================================================================================
Duration: 0.3 s

OK:       175
Failed:   3
Warnings: 0
Skipped:  1
```

#### This desktop metadata
```
packageDescription('glue')

Package: glue
Title: Interpreted String Literals
Version: 1.3.1
Authors@R: person("Jim", "Hester", email = "james.f.hester@gmail.com",
        role = c("aut", "cre"))
Description: An implementation of interpreted string literals, inspired
        by Python's Literal String Interpolation
        <https://www.python.org/dev/peps/pep-0498/> and Docstrings
        <https://www.python.org/dev/peps/pep-0257/> and Julia's
        Triple-Quoted String Literals
        <https://docs.julialang.org/en/stable/manual/strings/#triple-quoted-string-literals>.
Depends: R (>= 3.1)
Imports: methods
Suggests: testthat, covr, magrittr, crayon, knitr, rmarkdown, DBI,
        RSQLite, R.utils, forcats, microbenchmark, rprintf, stringr,
        ggplot2, dplyr, withr
License: MIT + file LICENSE
Encoding: UTF-8
LazyData: true
RoxygenNote: 6.1.1
URL: https://github.com/tidyverse/glue
BugReports: https://github.com/tidyverse/glue/issues
VignetteBuilder: knitr
ByteCompile: true
NeedsCompilation: yes
Packaged: 2019-03-11 21:03:11 UTC; jhester
Author: Jim Hester [aut, cre]
Maintainer: Jim Hester <james.f.hester@gmail.com>
Repository: CRAN
Date/Publication: 2019-03-12 22:30:02 UTC
Built: R 3.5.3; x86_64-w64-mingw32; 2019-04-10 23:00:13 UTC; windows

-- File: C:/Users/AlecW/Documents/R/win-library/3.5/glue/Meta/package.rds 

sessionInfo()

R version 3.5.3 (2019-03-11)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 18363)

Matrix products: default

locale:
[1] LC_COLLATE=English_United States.1252  LC_CTYPE=English_United States.1252   
[3] LC_MONETARY=English_United States.1252 LC_NUMERIC=C                          
[5] LC_TIME=English_United States.1252    

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] crayon_1.3.4         testthat_2.0.1       glue_1.3.1          
[4] RevoUtils_11.0.3     RevoUtilsMath_11.0.0

loaded via a namespace (and not attached):
[1] compiler_3.5.3   assertthat_0.2.1 magrittr_1.5     R6_2.3.0        
[5] cli_1.1.0        tools_3.5.3      rstudioapi_0.10  rlang_0.3.4 
```

Also on work laptop (sesson info etc. in #158)
