### PR TITLE
Improve handling of lines containing only indentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 * `single_quote()` `double_quote()` and `backtick()` all return `NA` for `NA`
   inputs (#135).
 
+* Improve `trim()`'s handling of lines containing only indentation (#162)
+
 # glue 1.3.1
 
 ## Features

--- a/src/trim.c
+++ b/src/trim.c
@@ -84,6 +84,7 @@ SEXP trim_(SEXP x) {
           i += min_indent;
         }
         new_line = false;
+        continue;
       }
       str[j++] = xx[i++];
     }

--- a/tests/testthat/test-trim.R
+++ b/tests/testthat/test-trim.R
@@ -115,3 +115,25 @@ test_that("issue#47", {
            * one bullet
          "), expected)
 })
+
+test_that("lines containing only indentation are handled properly", {
+  # Tabs and spaces are considered indentation. The following examples look
+  # funny because I'm using a tab escape as the last indentation character to
+  # prevent RStudio from removing trailing whitespace on save.
+  expect_identical(
+    trim("
+         \ta
+         \tb
+         \t
+         \tc"),
+    "a\nb\n\nc"
+  )
+  expect_identical(
+    trim("
+         \ta
+       \tb
+         \t
+         \tc"),
+    " \ta\nb\n \t\n \tc"
+  )
+})


### PR DESCRIPTION
Previously, after a `'\n'` was encountered while copying, `min_indent` number of characters are trimmed from the beginning of lines by seeking `i` characters ahead in the input string.

However, after setting `i += min_indent`, `i` was incremented again right before the `while` loop continued via `str[j++] = xx[i++]`. This caused `i` to point to the character *after* the `'\n`' that terminated the line, and so leading indentation on the *following* line was not recognized as such, and so was improperly copied to the output string.

While working on this, I also ran into a few other possible bugs:

1. Lines containing only indentation might be shorter than `min_indent` and so could cause the succeeding line to contain spurious leading indentation. Currently, `trim()` only works properly if there's either no whitespace on the blank line, or if there is an amount of whitespace of at least `min_indent`.
1. Tabs are not converted to spaces, and so output may appear to be improperly indented even after trimming if different lines contain different distributions of leading tab and space characters.

Let me know if it would be helpful for me to create issues for those possible bugs. I didn't create issues because maybe these are features 😄 

It also occurred to @wch and I while working on this that we could probably be smarter about the size of the output string we allocate. Since we know that `min_indent` will removed from *every* line after the first, in the `min_indent` calculation pass we could tally newlines and multiply that tally by the size of `min_indent` to determine how much smaller the output string needs to be.

# TODO

- [x] Update NEWS