### PR TITLE
Clarify how named paramters passed to `...` are used

### DIFF
--- a/R/glue.R
+++ b/R/glue.R
@@ -5,7 +5,9 @@
 #' from the first and last lines are automatically trimmed.
 #'
 #' @param .x \[`listish`]\cr An environment, list or data frame used to lookup values.
-#' @param ... \[`expressions`]\cr Expressions string(s) to format, multiple inputs are concatenated together before formatting.
+#' @param ... \[`expressions`]\cr Unnamed arguments are taken to be expressions
+#'     string(s) to format. Multiple inputs are concatenated together before formatting.
+#'     Named arguments are taken to be temporary variables available for substitution.
 #' @param .sep \[`character(1)`: \sQuote{""}]\cr Separator used to separate elements.
 #' @param .envir \[`environment`: `parent.frame()`]\cr Environment to evaluate each expression in. Expressions are
 #'   evaluated from left to right. If `.x` is an environment, the expressions are

--- a/man/glue.Rd
+++ b/man/glue.Rd
@@ -31,7 +31,9 @@ glue(
 \arguments{
 \item{.x}{[\code{listish}]\cr An environment, list or data frame used to lookup values.}
 
-\item{...}{[\code{expressions}]\cr Expressions string(s) to format, multiple inputs are concatenated together before formatting.}
+\item{...}{[\code{expressions}]\cr Unnamed arguments are taken to be expressions
+string(s) to format. Multiple inputs are concatenated together before formatting.
+Named arguments are taken to be temporary variables available for substitution.}
 
 \item{.sep}{[\code{character(1)}: \sQuote{""}]\cr Separator used to separate elements.}
 

--- a/man/glue_col.Rd
+++ b/man/glue_col.Rd
@@ -10,7 +10,9 @@ glue_col(..., .envir = parent.frame(), .na = "NA")
 glue_data_col(.x, ..., .envir = parent.frame(), .na = "NA")
 }
 \arguments{
-\item{...}{[\code{expressions}]\cr Expressions string(s) to format, multiple inputs are concatenated together before formatting.}
+\item{...}{[\code{expressions}]\cr Unnamed arguments are taken to be expressions
+string(s) to format. Multiple inputs are concatenated together before formatting.
+Named arguments are taken to be temporary variables available for substitution.}
 
 \item{.envir}{[\code{environment}: \code{parent.frame()}]\cr Environment to evaluate each expression in. Expressions are
 evaluated from left to right. If \code{.x} is an environment, the expressions are
@@ -27,7 +29,7 @@ The \link[crayon:crayon]{crayon} package defines a number of functions used to
 color terminal output. \code{glue_col()} and \code{glue_data_col()} functions provide
 additional syntax to make using these functions in glue strings easier.
 
-Using the following syntax will apply the function \code{blue} function to the text 'foo bar'.\preformatted{\{blue foo bar\}
+Using the following syntax will apply the function \code{crayon::blue()} to the text 'foo bar'.\preformatted{\{blue foo bar\}
 }
 
 If you want an expression to be evaluated, simply place that in a normal brace

--- a/man/glue_sql.Rd
+++ b/man/glue_sql.Rd
@@ -10,7 +10,9 @@ glue_sql(..., .con, .envir = parent.frame(), .na = DBI::SQL("NULL"))
 glue_data_sql(.x, ..., .con, .envir = parent.frame(), .na = DBI::SQL("NULL"))
 }
 \arguments{
-\item{...}{[\code{expressions}]\cr Expressions string(s) to format, multiple inputs are concatenated together before formatting.}
+\item{...}{[\code{expressions}]\cr Unnamed arguments are taken to be expressions
+string(s) to format. Multiple inputs are concatenated together before formatting.
+Named arguments are taken to be temporary variables available for substitution.}
 
 \item{.con}{[\code{DBIConnection}]:A DBI connection object obtained from \code{DBI::dbConnect()}.}
 


### PR DESCRIPTION
For a long time, I didn't realize you could use named parameters (temporary variables to be interpolated) in `glue::glue()`'s `...` because the parameter documentation only specified its behavior with unnamed parameters (string patterns to substitute). The named behavior was documented in comments in the examples, but, well, I (and I assume a lot of other people) never made it that far into the docs.

This PR just updates the parameter documentation for `...` to include both behaviors. I'm happy to reword it if you'd like.