### PR TITLE
Update to use vctrs type errors, not cast errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Suggests:
     ggplot2,
     dplyr,
     withr,
-    vctrs (>= 0.2.2)
+    vctrs (>= 0.2.99.9011)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
@@ -37,3 +37,5 @@ URL: https://github.com/tidyverse/glue, https://glue.tidyverse.org/
 BugReports: https://github.com/tidyverse/glue/issues
 VignetteBuilder: knitr
 ByteCompile: true
+Remotes:
+    r-lib/vctrs

--- a/tests/testthat/test-vctrs.R
+++ b/tests/testthat/test-vctrs.R
@@ -47,19 +47,19 @@ test_that("glue and character are coercible", {
 test_that("coercion is not inherited", {
   expect_error(
     vctrs::vec_cast(glue(), structure(character(), class = "foobar")),
-    class = "vctrs_error_incompatible_cast"
+    class = "vctrs_error_incompatible_type"
   )
   expect_error(
     vctrs::vec_cast(structure(character(), class = "foobar"), glue()),
-    class = "vctrs_error_incompatible_cast"
+    class = "vctrs_error_incompatible_type"
   )
   expect_error(
     vctrs::vec_cast(character(), structure(glue(), class = "foobar")),
-    class = "vctrs_error_incompatible_cast"
+    class = "vctrs_error_incompatible_type"
   )
   expect_error(
     vctrs::vec_cast(structure(glue(), class = "foobar"), character()),
-    class = "vctrs_error_incompatible_cast"
+    class = "vctrs_error_incompatible_type"
   )
 })
 


### PR DESCRIPTION
See  https://github.com/r-lib/vctrs/pull/983 for full details.

The development version of vctrs now throws `vctrs_error_incompatible_type` errors when casting is not allowed, rather than `vctrs_error_incompatible_cast`. This better aligns `vec_ptype2()` and `vec_cast()` now that they share the same coercion hierarchy.