### PR TITLE
added a "squish" option for .trim

### DIFF
--- a/R/glue.R
+++ b/R/glue.R
@@ -112,6 +112,8 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
   unnamed_args <- paste0(unnamed_args, collapse = .sep)
   if (isTRUE(.trim)) {
     unnamed_args <- trim(unnamed_args)
+  } else if(identical(.trim, "squish") {
+    unnamed_args <- stringr::str_squish(unnamed_args)
   }
 
   f <- function(expr){


### PR DESCRIPTION
I think it would be very nice if the glue function could `stringr::str_squish` the resulting string, instead of just trimming it:

``` r
library(glue)
x=55
glue("My value   x is   equal to {x}")
#> My value   x is   equal to 55

#with the PR
glue("My value   x is   equal to {x}", .trim="squish")
#> My value x is equal to 55
```
<sup>Created on 2020-06-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Glued objects might have extra spaces and keeping count of them is sometimes annoying. Having this feature directly inside `glue` avoids having to import `stringr` and call `str_squish`, which I often find myself doing.

IMHO, this could even be the default behavior (right now, I cannot see any good reason not to squish if you want to trim), although it might break backward compatibility.

This might need refactoring to avoid the dependency to `stringr`, depending on the maintainers' will (I did not  even add the @importFrom mention for this reason).