### PR TITLE
Slightly improve glue_safe() error message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # glue (development version)
 
+* `glue_safe()` gives a slightly nicer error message
 * The required version of R is now 3.2 (#189)
 * `glue_sql()` now collapses `DBI::SQL()` elements correctly (#192 @shrektan)
 * The internal `compare()` method gains a `...` argument, for compatibility with testthat 3.0.0

--- a/R/safe.R
+++ b/R/safe.R
@@ -18,11 +18,19 @@
 #'
 #' rm("1 + 1")
 glue_safe <- function(..., .envir = parent.frame()) {
-  glue(..., .envir = .envir, .transformer = base::get)
+  glue(..., .envir = .envir, .transformer = get_transformer)
 }
 
 #' @rdname glue_safe
 #' @export
 glue_data_safe <- function(.x, ..., .envir = parent.frame()) {
-  glue_data(.x, ..., .envir = .envir, .transformer = base::get)
+  glue_data(.x, ..., .envir = .envir, .transformer = get_transformer)
+}
+
+get_transformer <- function(text, envir) {
+  if (!exists(text, envir = envir)) {
+    stop("object '", text, "' not found", call. = FALSE)
+  } else {
+    get(text, envir = envir)
+  }
 }


### PR DESCRIPTION
```R
# BEFORE
glue::glue_safe("{zzz}")
#> Error in .transformer(expr, env) : object 'zzz' not found

# AFTER
glue::glue_safe("{zzz}")
#> Error: object 'zzz' not found
```