### PR TITLE
Reduce R CMD check issue to WARNING when magrittr is unavailable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Suggests:
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 URL: https://github.com/tidyverse/glue, https://glue.tidyverse.org/
 BugReports: https://github.com/tidyverse/glue/issues

--- a/R/glue.R
+++ b/R/glue.R
@@ -53,13 +53,14 @@
 #' intro("Cate", "Data Scientist", "Kenya")
 #'
 #' # `glue_data()` is useful in magrittr pipes
-#' library(magrittr)
-#' mtcars %>% glue_data("{rownames(.)} has {hp} hp")
+#' if (require(magrittr)) {
+#'   mtcars %>% glue_data("{rownames(.)} has {hp} hp")
 #'
-#' # Or within dplyr pipelines
-#' library(dplyr)
-#' head(iris) %>%
-#'   mutate(description = glue("This {Species} has a petal length of {Petal.Length}"))
+#'   # Or within dplyr pipelines
+#'   library(dplyr)
+#'   head(iris) %>%
+#'     mutate(description = glue("This {Species} has a petal length of {Petal.Length}"))
+#' }
 #'
 #' # Alternative delimiters can also be used if needed
 #' one <- "1"

--- a/R/glue.R
+++ b/R/glue.R
@@ -54,13 +54,16 @@
 #'
 #' # `glue_data()` is useful in magrittr pipes
 #' if (require(magrittr)) {
-#'   mtcars %>% glue_data("{rownames(.)} has {hp} hp")
 #'
-#'   # Or within dplyr pipelines
-#'   library(dplyr)
-#'   head(iris) %>%
-#'     mutate(description = glue("This {Species} has a petal length of {Petal.Length}"))
-#' }
+#' mtcars %>% glue_data("{rownames(.)} has {hp} hp")
+#'
+#' # Or within dplyr pipelines
+#' if (require(dplyr)) {
+#'
+#' head(iris) %>%
+#'   mutate(description = glue("This {Species} has a petal length of {Petal.Length}"))
+#'
+#' }}
 #'
 #' # Alternative delimiters can also be used if needed
 #' one <- "1"

--- a/man/glue.Rd
+++ b/man/glue.Rd
@@ -90,13 +90,14 @@ intro("Shelmith", "Senior Data Analyst", "Kenya")
 intro("Cate", "Data Scientist", "Kenya")
 
 # `glue_data()` is useful in magrittr pipes
-library(magrittr)
-mtcars \%>\% glue_data("{rownames(.)} has {hp} hp")
+if (require(magrittr)) {
+  mtcars \%>\% glue_data("{rownames(.)} has {hp} hp")
 
-# Or within dplyr pipelines
-library(dplyr)
-head(iris) \%>\%
-  mutate(description = glue("This {Species} has a petal length of {Petal.Length}"))
+  # Or within dplyr pipelines
+  library(dplyr)
+  head(iris) \%>\%
+    mutate(description = glue("This {Species} has a petal length of {Petal.Length}"))
+}
 
 # Alternative delimiters can also be used if needed
 one <- "1"

--- a/man/glue.Rd
+++ b/man/glue.Rd
@@ -91,13 +91,16 @@ intro("Cate", "Data Scientist", "Kenya")
 
 # `glue_data()` is useful in magrittr pipes
 if (require(magrittr)) {
-  mtcars \%>\% glue_data("{rownames(.)} has {hp} hp")
 
-  # Or within dplyr pipelines
-  library(dplyr)
-  head(iris) \%>\%
-    mutate(description = glue("This {Species} has a petal length of {Petal.Length}"))
-}
+mtcars \%>\% glue_data("{rownames(.)} has {hp} hp")
+
+# Or within dplyr pipelines
+if (require(dplyr)) {
+
+head(iris) \%>\%
+  mutate(description = glue("This {Species} has a petal length of {Petal.Length}"))
+
+}}
 
 # Alternative delimiters can also be used if needed
 one <- "1"

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -2,4 +2,5 @@ if (require(testthat)) {
   library(glue)
 
   test_check("glue")
-}
+} else
+  warning("'glue' requires 'testthat' for tests")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,5 @@
-library(testthat)
-library(glue)
+if (require(testthat)) {
+  library(glue)
 
-test_check("glue")
+  test_check("glue")
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,6 +1,3 @@
-if (require(testthat)) {
-  library(glue)
+library(glue)
 
-  test_check("glue")
-} else
-  warning("'glue' requires 'testthat' for tests")
+test_check("glue")


### PR DESCRIPTION
`glue` fails tests on CRAN in winUCRT because `magrittr` is missing.  This causes a huge cascade of failures of packages that depend on `glue`.

`magrittr` is a suggested package, so its presence should be optional.  `glue` should be able to pass tests on CRAN with no ERRORs even if suggested packages are missing.

* `rmarkdown` needs `magrittr` and the vignettes need `rmarkdown`, so build the tarball before removing `magrittr`.
* `devtools` needs `magrittr`, so use `R CMD check` on the tarball instead.
* `roxygen2` needs `magrittr`, so roxygenize before getting rid of it.
* `testthat` needs `magrittr`, so `testthat` tests are now conditionalized.

This PR reduces the `glue` problems to a warning about being unable to build the vignettes because of  `rmarkdown` not working.  I don't know CRAN policy well enough to know if a warning will stop `glue` from being made available, but it's an improvement.
