### PR TITLE
Implement `.null` argument

### DIFF
--- a/man/glue.Rd
+++ b/man/glue.Rd
@@ -13,6 +13,7 @@ glue_data(
   .open = "{",
   .close = "}",
   .na = "NA",
+  .null = NULL,
   .transformer = identity_transformer,
   .trim = TRUE
 )
@@ -24,6 +25,7 @@ glue(
   .open = "{",
   .close = "}",
   .na = "NA",
+  .null = NULL,
   .transformer = identity_transformer,
   .trim = TRUE
 )
@@ -50,6 +52,10 @@ full delimiter escapes it.}
 \item{.na}{[\code{character(1)}: \sQuote{NA}]\cr Value to replace NA values
 with. If \code{NULL} missing values are propagated, that is an \code{NA} result will
 cause \code{NA} output. Otherwise the value is replaced by the value of \code{.na}.}
+
+\item{.null}{[\code{character(1)}: \sQuote{NULL}]\cr Value to replace NULL values
+with. If \code{NULL} whole output is \code{character(0)}. Otherwise the value is
+replaced by the value of \code{.null}.}
 
 \item{.transformer}{[\verb{function]}\cr A function taking three parameters \code{code}, \code{envir} and
 \code{data} used to transform the output of each block before during or after

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -368,6 +368,58 @@ test_that("glue always returns .na if given any NA input and `.na` != NULL", {
     c("1 - foo", "2 - baz", "3 - bar"))
 })
 
+test_that("glue always returns character(0) if given any NULL input and `.null` == NULL", {
+  expect_equal(
+    glue("{NULL}", .null = NULL),
+    character(0))
+
+  expect_equal(
+    glue("{}", .null = NULL),
+    character(0))
+
+  expect_equal(
+    glue(NULL, .null = NULL),
+    character(0))
+
+  expect_equal(
+    glue(NULL, 1, .null = NULL),
+    character(0))
+
+  expect_equal(
+    glue(1, NULL, 2, .null = NULL),
+    character(0))
+
+  expect_equal(
+    glue("x: ", if (FALSE) "positive", .null = NULL),
+    character(0))
+})
+
+test_that("glue always returns .null if given any NULL input and `.null` != NULL", {
+  expect_equal(
+    glue("{NULL}", .null = "foo"),
+    "foo")
+
+  expect_equal(
+    glue("{}", .null = "foo"),
+    "foo")
+
+  expect_equal(
+    glue(NULL, .null = "foo"),
+    "foo")
+
+  expect_equal(
+    glue(NULL, 1, .null = "foo"),
+    "foo1")
+
+  expect_equal(
+    glue(1, NULL, 2, .null = "foo"),
+    "1foo2")
+
+  expect_equal(
+    glue("x: ", if (FALSE) "positive", .null = "foo"),
+    "x: foo")
+})
+
 test_that("glue works within functions", {
   x <- 1
   f <- function(msg) glue(msg, .envir = parent.frame())


### PR DESCRIPTION
This PR add `.null` argument to `glue()` and `glue_data()`. As it was [suggested in comment](https://github.com/tidyverse/glue/issues/84#issuecomment-718624072), this fixes #84.