### PR TITLE
crayon from glue

### DIFF
--- a/R/color.R
+++ b/R/color.R
@@ -17,8 +17,8 @@
 #' ```
 #' {blue 1 + 1 = {1 + 1}}
 #' ```
-#'
 #' @inheritParams glue
+#'
 #' @export
 #' @examples
 #' if (require(crayon)) {
@@ -36,6 +36,9 @@
 #' }
 glue_col <- function(..., .envir = parent.frame(), .na = "NA") {
   loadNamespace("crayon")
+  if(!"crayon" %in% (.packages())){
+    library(crayon)
+  }
   glue(..., .envir = .envir, .na = .na, .transformer = color_transformer)
 }
 
@@ -43,6 +46,9 @@ glue_col <- function(..., .envir = parent.frame(), .na = "NA") {
 #' @export
 glue_data_col <- function(.x, ..., .envir = parent.frame(), .na = "NA") {
   loadNamespace("crayon")
+  if(!"crayon" %in% (.packages())){
+    library(crayon)
+  }
   glue_data(.x, ..., .envir = .envir, .na = .na, .transformer = color_transformer)
 }
 


### PR DESCRIPTION
Loads crayon when using `glue_col()`.

Possibly closes #196 

Before:
```
> library(glue)
Warning message:
package ‘glue’ was built under R version 4.0.5 
> glue_col("{blue 1 + 1 = {1 + 1}}")
Error in get(fun, envir = envir, mode = "function") : 
  object 'blue' of mode 'function' was not found
```

After:
```
> devtools::load_all()
i Loading glue
Warning message:
package ‘testthat’ was built under R version 4.0.5 

> library(glue)
> glue_col("{blue 1 + 1 = {1 + 1}}")
1 + 1 = 2
Warning message:
package ‘crayon’ was built under R version 4.0.5 
```