### PR TITLE
Evaluate in the empty environment

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -149,7 +149,7 @@ SEXP glue_(SEXP x, SEXP f, SEXP open_arg, SEXP close_arg, SEXP comment_arg) {
         SEXP expr = PROTECT(Rf_ScalarString(
             Rf_mkCharLenCE(&xx[start], (i - close_len) + 1 - start, CE_UTF8)));
         SEXP call = PROTECT(Rf_lang2(f, expr));
-        SEXP result = PROTECT(Rf_eval(call, R_GlobalEnv));
+        SEXP result = PROTECT(Rf_eval(call, R_EmptyEnv));
 
         /* text in between last glue statement */
         if (j > 0) {


### PR DESCRIPTION
While studying glue and, specifically, the evaluation environment, I was a bit puzzled when I came across `R_GlobalEnv` in

https://github.com/tidyverse/glue/blob/4de8c402e3c37798305e7e8c1c54265bdbecf2ab/src/glue.c#L151-L152

as `f()` (formed on the R side) comes with the relevant environment chain already "baked in".

It seems to me the environment for evaluating this call should not matter and I think using `R_EmptyEnv` makes what's going on more clear. I take great comfort in the passing tests.