### PR TITLE
glue_sql() collapses zero-length DBI::SQL object into `DBI::SQL("NULL")`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
 # glue (development version)
 
-The existing custom language engines for knitr, `glue` and `glue_sql`, are documented in a new vignette (#71).
+* The existing custom language engines for knitr, `glue` and `glue_sql`, are documented in a new vignette (#71).
 
-`glue_col()` gives special treatment to styling functions from the crayon package, e.g. `glue_col("{blue foo}")` "just works" now, even if crayon is not attached (but is installed) (#241).
+* `glue_col()` gives special treatment to styling functions from the crayon package, e.g. `glue_col("{blue foo}")` "just works" now, even if crayon is not attached (but is installed) (#241).
 
-Unterminated backticks trigger the same error as unterminated single or double quotes (#237).
+* Unterminated backticks trigger the same error as unterminated single or double quotes (#237).
+
+* `glue_sql()` collapses zero-length `DBI::SQL` object into `DBI::SQL("NULL")` (#244 @shrektan).
 
 # glue 1.5.0
 

--- a/R/sql.R
+++ b/R/sql.R
@@ -174,6 +174,9 @@ sql_quote_transformer <- function(connection, .na) {
         if (should_collapse) {
           res <- glue_collapse(res, ", ")
         }
+        if (length(res) == 0L) {
+          res <- DBI::SQL("NULL")
+        }
         return(res)
       }
 

--- a/tests/testthat/test-sql.R
+++ b/tests/testthat/test-sql.R
@@ -48,6 +48,7 @@ describe("glue_sql", {
   })
   it('collapses values should return NULL for length zero vector', {
     expect_identical(glue_sql("{var*}", .con = con, var = character()), DBI::SQL("NULL"))
+    expect_identical(glue_sql("{var*}", .con = con, var = DBI::SQL(character())), DBI::SQL("NULL"))
   })
   it("should return an SQL NULL by default for missing values", {
     var <- list(NA, NA_character_, NA_real_, NA_integer_)


### PR DESCRIPTION
This is a missed case of #134

The real use case that hurts in reality is :

When using Oracle database, the date object must be in format like `date'yyyy-mm-dd'`. Thus, we need to do: 

```r
sql_dates <- DBI::SQL(sprintf("date'%s'", dates))
glue::glue_sql("select * from table where ref_date in ({sql_dates*})", .con = con)
```

Thus, when `dates` is zero-length, `sql_dates` would be zero-length as well, but it leads to an empty SQL string in the current version of glue.

This PR fixes this. It results a valid SQL: `select * from table where ref_date in (NULL)`