### PR TITLE
fix image hyperlink

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(
 library(glue)
 ```
 
-# glue <a href='https:/glue.tidyverse.org'><img src='man/figures/logo.png' align="right" height="139" /></a>
+# glue [<img src='man/figures/logo.png' align="right" height="139" />](https://glue.tidyverse.org)
 
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/glue)](https://cran.r-project.org/package=glue)
 [![R build status](https://github.com/tidyverse/glue/workflows/R-CMD-check/badge.svg)](https://github.com/tidyverse/glue/actions)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# glue <a href='https:/glue.tidyverse.org'><img src='man/figures/logo.png' align="right" height="139" /></a>
+# glue [<img src='man/figures/logo.png' align="right" height="139" />](https://glue.tidyverse.org)
 
 [![CRAN_Status_Badge](https://www.r-pkg.org/badges/version/glue)](https://cran.r-project.org/package=glue)
 [![R build


### PR DESCRIPTION
I noticed that the hyperlink for the glue package's image was going to `https://github.com/glue.tidyverse.org`. I changed `README.md` and `README.Rmd`, using https://github.com/rstudio/pins as an example:
* https://github.com/rstudio/pins/blob/1ba46ade3247558153782b5c029acd8df0dcffd4/README.Rmd#L18
* https://github.com/rstudio/pins/blob/1ba46ade3247558153782b5c029acd8df0dcffd4/README.md?plain=1#L2