### PR TITLE
Make `.onLoad()` more robust w.r.t. knitr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # glue (development version)
 
+* glue now registers its custom knitr engines in a way that is more robust to namespace-loading edge cases that can arise during package installation (#254).
+
 # glue 1.6.0
 
 * `glue()`, `glue_data()`, `glue_col()`, and `glue_data_col()` gain a new `.literal` argument, which controls how quotes and the comment character are treated when parsing the expression string (#235). This is mostly useful when using a custom transformer.
@@ -10,7 +12,7 @@
 
 * Jennifer Bryan is now the maintainer.
 
-* The existing custom language engines for knitr, `glue` and `glue_sql`, are documented in a new vignette (#71).
+* The existing custom language engines for knitr, `glue` and `glue_sql`, are documented in a new vignette (#71). *Detail added after release: glue now sets up registration of these engines in `.onLoad()`.*
 
 * `glue_col()` gives special treatment to styling functions from the crayon package, e.g. `glue_col("{blue foo}")` "just works" now, even if crayon is not attached (but is installed) (#241).
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,7 +11,6 @@
   s3_register("vctrs::vec_cast", "character.glue")
   s3_register("vctrs::vec_cast", "glue.character")
 
-  # comment
   if (isNamespaceLoaded("knitr") &&
       "knit_engines" %in% getNamespaceExports("knitr")) {
     knitr::knit_engines$set(glue = eng_glue, glue_sql = eng_glue_sql, gluesql = eng_glue_sql)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -12,7 +12,8 @@
   s3_register("vctrs::vec_cast", "glue.character")
 
   # comment
-  if (isNamespaceLoaded("knitr")) {
+  if (isNamespaceLoaded("knitr") &&
+      "knit_engines" %in% getNamespaceExports("knitr")) {
     knitr::knit_engines$set(glue = eng_glue, glue_sql = eng_glue_sql, gluesql = eng_glue_sql)
   } else {
     setHook(packageEvent("knitr", "onLoad"), function(...) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,6 +11,7 @@
   s3_register("vctrs::vec_cast", "character.glue")
   s3_register("vctrs::vec_cast", "glue.character")
 
+  # comment
   if (isNamespaceLoaded("knitr")) {
     knitr::knit_engines$set(glue = eng_glue, glue_sql = eng_glue_sql, gluesql = eng_glue_sql)
   } else {


### PR DESCRIPTION
Closes #253 

This generated extensive discussion in Slack, which I'll summarize here.

The root cause is arguably an infelicity in R; specifically in `isNamespaceLoaded()`. These failures occur when glue is being loaded while knitr's namespace is "sort of" loaded. It's loaded enough for `isNamespaceLoaded()` to return `TRUE`, but not loaded enough for `knitr::knit_engines$set()` to succeed. It feels like this should never happen, yet that's what's causing these failures.

We first really noticed this in stringr's CI for ubuntu-18.04 (devel), e.g. https://github.com/tidyverse/stringr/actions/runs/1725746423. But it has nothing to do with r-devel or CI, but rather it's seen when installing packages from source, in a particular order. The phenomenon has been seen with R 4.1 by a regular user (https://github.com/yihui/knitr/issues/2087). It has been seen in CI with Windows and R 3.6 (https://github.com/tidyverse/stringr/runs/4417596611?check_suite_focus=true). And we've been able to replicate it now.

So why did stringr surface this problem? It seems to be the combination of two recent changes:

* (This is not new, but is relevant: knitr Imports stringr, stringr Imports glue.)
    ``` r
    pak::pkg_deps_explain("knitr", "glue")
    #> knitr -> stringr -> glue
    ```
* glue gained [this knitr-involving](https://github.com/tidyverse/glue/blob/2a66e6d15702cb2c676775e3b8639415b22e7d2b/R/zzz.R#L14-L20) code in `.onLoad()` in [version 1.5.1](https://github.com/tidyverse/glue/releases/tag/v1.5.1)
    ``` r
    if (isNamespaceLoaded("knitr")) {
      knitr::knit_engines$set(glue = eng_glue, glue_sql = eng_glue_sql, gluesql = eng_glue_sql)
    } else {
      setHook(packageEvent("knitr", "onLoad"), function(...) {
        knitr::knit_engines$set(glue = eng_glue, glue_sql = eng_glue_sql, gluesql = eng_glue_sql)
      })
    }
    ```
* stringr gained `importFrom(glue,glue)` in its NAMESPACE in https://github.com/tidyverse/stringr/commit/ad7fe116072dc74420344b7de5bd931db1da34c6#diff-b6b6854a02ae177f8860f49654ff250c1554d021ae434b6efdbe99d00bdc6055

Nice summary from @gaborcsardi:

> ... the issue is that the knitr loading triggers stringr loading, which triggers glue loading, and glue thinks that knitr is already loaded, but in fact it is "half-loaded", and not in a usable state yet.

We have consensus that the specific fix in this PR is reasonable and the broader issue re: `isNamespaceLoaded()` has been raised on the r-devel mailing list ([isNamespaceLoaded() while the namespace is loading](https://stat.ethz.ch/pipermail/r-devel/2022-January/081431.html)).