### PR TITLE
`onload`: Fix `knitr` lazy loading on `R-devel`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glue (development version)
 
-* Fixed `knitr` lazy loading on `R-devel` (#253 @hsbadr).
+* Fixed `knitr` lazy loading on `R-devel` (#255 @hsbadr).
 
 # glue 1.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # glue (development version)
 
+* Fixed `knitr` lazy loading on `R-devel` (#253 @hsbadr).
+
 # glue 1.6.0
 
 * `glue()`, `glue_data()`, `glue_col()`, and `glue_data_col()` gain a new `.literal` argument, which controls how quotes and the comment character are treated when parsing the expression string (#235). This is mostly useful when using a custom transformer.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,9 +11,11 @@
   s3_register("vctrs::vec_cast", "character.glue")
   s3_register("vctrs::vec_cast", "glue.character")
 
-  if (require("knitr", quietly = TRUE)) {
-    knitr::knit_engines$set(glue = eng_glue, glue_sql = eng_glue_sql, gluesql = eng_glue_sql)
-  } else {
+  eng_try <- try(
+    knitr::knit_engines$set(glue = eng_glue, glue_sql = eng_glue_sql, gluesql = eng_glue_sql),
+    silent = TRUE
+  )
+  if (inherits(eng_try, "try-error")) {
     setHook(packageEvent("knitr", "onLoad"), function(...) {
       knitr::knit_engines$set(glue = eng_glue, glue_sql = eng_glue_sql, gluesql = eng_glue_sql)
     })

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -11,7 +11,7 @@
   s3_register("vctrs::vec_cast", "character.glue")
   s3_register("vctrs::vec_cast", "glue.character")
 
-  if (isNamespaceLoaded("knitr")) {
+  if (require("knitr", quietly = TRUE)) {
     knitr::knit_engines$set(glue = eng_glue, glue_sql = eng_glue_sql, gluesql = eng_glue_sql)
   } else {
     setHook(packageEvent("knitr", "onLoad"), function(...) {


### PR DESCRIPTION
Close #253.

This issue can be reproduced locally with the latest `R-devel` revisions using:
```r
remotes::install_github("tidyverse/glue", force = TRUE)
remotes::install_github("yihui/knitr", force = TRUE)
```
It only affects the installation of `knitr`; it's ok at runtime. Apparently, it's a race condition (cyclic namespace dependency) introduced lately, where `knitr` namespace is being loaded for `glue` while `knitr` is being installed.
