### PR TITLE
Correct documentation of `glue_sql()`'s `.na` argument default value

### DIFF
--- a/R/sql.R
+++ b/R/sql.R
@@ -25,6 +25,10 @@
 #' @seealso [glue_sql_collapse()] to collapse [DBI::SQL()] objects.
 #' @param .con \[`DBIConnection`]: A DBI connection object obtained from
 #'   [DBI::dbConnect()].
+#' @param .na \[`character(1)`: `DBI::SQL("NULL")`]\cr Value to replace
+#'   `NA` values with. If `NULL` missing values are propagated, that is an `NA`
+#'   result will cause `NA` output. Otherwise the value is replaced by the
+#'   value of `.na`.
 #' @return A [DBI::SQL()] object with the given query.
 #' @examplesIf requireNamespace("DBI", quietly = TRUE) && requireNamespace("RSQLite", quietly = TRUE)
 #' con <- DBI::dbConnect(RSQLite::SQLite(), ":memory:")

--- a/man/glue_sql.Rd
+++ b/man/glue_sql.Rd
@@ -21,9 +21,10 @@ Named arguments are taken to be temporary variables available for substitution.}
 evaluated from left to right. If \code{.x} is an environment, the expressions are
 evaluated in that environment and \code{.envir} is ignored. If \code{NULL} is passed, it is equivalent to \code{\link[=emptyenv]{emptyenv()}}.}
 
-\item{.na}{[\code{character(1)}: \sQuote{NA}]\cr Value to replace \code{NA} values
-with. If \code{NULL} missing values are propagated, that is an \code{NA} result will
-cause \code{NA} output. Otherwise the value is replaced by the value of \code{.na}.}
+\item{.na}{[\code{character(1)}: \code{DBI::SQL("NULL")}]\cr Value to replace
+\code{NA} values with. If \code{NULL} missing values are propagated, that is an \code{NA}
+result will cause \code{NA} output. Otherwise the value is replaced by the
+value of \code{.na}.}
 
 \item{.x}{[\code{listish}]\cr An environment, list, or data frame used to lookup values.}
 }


### PR DESCRIPTION
Closes #261.

`glue_sql()` inherits the `.na` documentation from `glue()`. However, this argument's default value is different between the functions. Since the arguments are all documented with a `[type : default-value]` format, `glue_sql()`'s man page also shows its default value as `'NA'`, not the correct `DBI::SQL("NULL").

This PR merely copies the `.na` documentation from `glue()` wholesale and then changes the default value description.