### PR TITLE
signif() transformer example

### DIFF
--- a/vignettes/transformers.Rmd
+++ b/vignettes/transformers.Rmd
@@ -125,7 +125,7 @@ glue_ji("many :heart*:")
 
 ### sprintf transformer
 
-A transformer which allows succinct sprintf format strings.
+A transformer which allows succinct `sprintf` format strings.
 
 ```{r}
 sprintf_transformer <- function(text, envir) {
@@ -145,6 +145,31 @@ glue_fmt <- function(..., .envir = parent.frame()) {
 }
 glue_fmt("π = {pi:.3f}")
 ```
+
+### signif transformer
+
+A transformer generator that represents numbers with a given number of significant digits.
+This is useful if we want to represent all numbers using the same significant digits
+
+```{r}
+signif_transformer <- function(digits = 3) {
+    force(digits)
+    function(text, envir) {
+        x <- identity_transformer(text, envir)
+        if (is.numeric(x)) {
+            signif(x, digits = digits)
+        } else {
+            x
+        }
+    }
+}
+glue_signif <- function(..., .envir = parent.frame()) {
+  glue(..., .transformer = signif_transformer(3), .envir = .envir)
+}
+
+glue_signif("π = {pi}; 10π = {10*pi}; 100π = {100*pi}")
+```
+
 
 ### safely transformer
 

--- a/vignettes/transformers.Rmd
+++ b/vignettes/transformers.Rmd
@@ -77,7 +77,7 @@ e.g. via `system()` or `system2()`.
 shell_transformer <- function(type = c("sh", "csh", "cmd", "cmd2")) {
   type <- match.arg(type)
   function(text, envir) {
-    res <- eval(parse(text = text, keep.source = FALSE), envir)
+    res <- identity_transformer(text, envir)
     shQuote(res)
   }
 }
@@ -133,10 +133,10 @@ sprintf_transformer <- function(text, envir) {
   if (m != -1) {
     format <- substring(regmatches(text, m), 2)
     regmatches(text, m) <- ""
-    res <- eval(parse(text = text, keep.source = FALSE), envir)
+    res <- identity_transformer(text, envir)
     do.call(sprintf, list(glue("%{format}"), res))
   } else {
-    eval(parse(text = text, keep.source = FALSE), envir)
+    identity_transformer(text, envir)
   }
 }
 
@@ -154,7 +154,7 @@ A transformer that acts like `purrr::safely()`, which returns a value instead of
 safely_transformer <- function(otherwise = NA) {
   function(text, envir) {
     tryCatch(
-      eval(parse(text = text, keep.source = FALSE), envir),
+      identity_transformer(text, envir),
       error = function(e) if (is.language(otherwise)) eval(otherwise) else otherwise)
   }
 }


### PR DESCRIPTION
Hi,

Thanks for the glue package.

I wrote a transformer to format numbers with a fixed number of significant figures. I used a function generator to do that, which is a convenient approach if we want all glued variables to have the same number of significant digits. I think this approach is not shown in the vignette, and it is worth so the example I added *(a)* introduces a new strategy for working with transformers and *(b)* provides an example to show a fixed number of significant figures.

Besides I converted some of the transformers in the vignette so they use the `identity_transformer()` helper function. I had no idea how transformers worked, and the `eval..parse` stuff was a bit confusing compared to just using the `identity_transformer()` helper.

If you like it, feel free to merge it.

Thanks again for your time and work!