### PR TITLE
typo: quote `hp` consistently

### DIFF
--- a/vignettes/engines.Rmd
+++ b/vignettes/engines.Rmd
@@ -74,12 +74,12 @@ In this example we use the `sqlite` engine, which uses backticks for quoting, bu
 `r '' ````{glue_sql, connection = con}
 SELECT `model`, `hp`, {`var`}
 FROM {`tbl`}
-WHERE {`tbl`}.hp > {num}
+WHERE {`tbl`}.`hp` > {num}
 ```
 ````
 
 ```{glue_sql, connection = con}
 SELECT `model`, `hp`, {`var`}
   FROM {`tbl`}
-  WHERE {`tbl`}.hp > {num}
+  WHERE {`tbl`}.`hp` > {num}
 ```


### PR DESCRIPTION
The `hp` column is used twice in the query and should be quoted in both places for consistency.