### PR TITLE
Add link to jinjar package

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -236,6 +236,7 @@ include.
 
 - [whisker](https://cran.r-project.org/package=whisker)
 - [brew](https://cran.r-project.org/package=brew)
+- [jinjar](https://cran.r-project.org/package=jinjar)
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ templating in R include.
 
 -   [whisker](https://cran.r-project.org/package=whisker)
 -   [brew](https://cran.r-project.org/package=brew)
+-   [jinjar](https://cran.r-project.org/package=jinjar)
 
 ## Code of Conduct
 


### PR DESCRIPTION
This is self-promotion, so please reject if you feel this is inappropriate.

I think the [jinjar](https://davidchall.github.io/jinjar/) package could be helpful to glue users who are looking for string templating.