### PR TITLE
Improve error clarity

### DIFF
--- a/src/glue.c
+++ b/src/glue.c
@@ -207,7 +207,7 @@ SEXP glue_(
     Rf_error("Unterminated quote (`)");
   } else if (state == comment) {
     free(str);
-    Rf_error("Unterminated comment");
+    Rf_error("Comments in glue expressions must be terminated by a newline.");
   }
 
   free(str);

--- a/src/glue.c
+++ b/src/glue.c
@@ -207,7 +207,7 @@ SEXP glue_(
     Rf_error("Unterminated quote (`)");
   } else if (state == comment) {
     free(str);
-    Rf_error("Comments in glue expressions must be terminated by a newline.");
+    Rf_error("A '#' comment in a glue expression must terminate with a newline.");
   }
 
   free(str);

--- a/tests/testthat/_snaps/color.md
+++ b/tests/testthat/_snaps/color.md
@@ -47,5 +47,5 @@
     Code
       glue_col("Hey a URL: {blue https://example.com/#section}")
     Error <simpleError>
-      Comments in glue expressions must be terminated by a newline.
+      A '#' comment in a glue expression must terminate with a newline.
 

--- a/tests/testthat/_snaps/color.md
+++ b/tests/testthat/_snaps/color.md
@@ -47,5 +47,5 @@
     Code
       glue_col("Hey a URL: {blue https://example.com/#section}")
     Error <simpleError>
-      Unterminated comment
+      Comments in glue expressions must be terminated by a newline.
 

--- a/tests/testthat/_snaps/glue.md
+++ b/tests/testthat/_snaps/glue.md
@@ -1,3 +1,17 @@
+# unterminated comment
+
+    Code
+      glue("pre {1 + 5 # comment} post")
+    Error <simpleError>
+      A '#' comment in a glue expression must terminate with a newline.
+
+---
+
+    Code
+      glue("pre {1 + 5 # comment")
+    Error <simpleError>
+      A '#' comment in a glue expression must terminate with a newline.
+
 # `.literal` treats quotes and `#` as regular characters
 
     Code

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -521,13 +521,13 @@ test_that("unterminated quotes are error", {
 })
 
 test_that("unterminated comment", {
-  expect_error(
-    glue("pre {1 + 5 # comment} post"),
-    "Comments in glue expressions must be terminated by a newline."
+  expect_snapshot(
+    error = TRUE,
+    glue("pre {1 + 5 # comment} post")
   )
-  expect_error(
-    glue("pre {1 + 5 # comment"),
-    "Comments in glue expressions must be terminated by a newline."
+  expect_snapshot(
+    error = TRUE,
+    glue("pre {1 + 5 # comment")
   )
 
   expect_equal(glue("pre {1 + 5 + #comment\n 4} post"), "pre 10 post")

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -521,8 +521,14 @@ test_that("unterminated quotes are error", {
 })
 
 test_that("unterminated comment", {
-  expect_error(glue("pre {1 + 5 # comment} post"), "Unterminated comment")
-  expect_error(glue("pre {1 + 5 # comment"), "Unterminated comment")
+  expect_error(
+    glue("pre {1 + 5 # comment} post"),
+    "Comments in glue expressions must be terminated by a newline."
+  )
+  expect_error(
+    glue("pre {1 + 5 # comment"),
+    "Comments in glue expressions must be terminated by a newline."
+  )
 
   expect_equal(glue("pre {1 + 5 + #comment\n 4} post"), "pre 10 post")
 })


### PR DESCRIPTION
I was playing around with coverage tests in a function using `glue()` and was puzzled by this error. I wasn't sure if it was coming from the R parser, or how to deal with it, since the code looks reasonable enough to me:

```r
glue::glue("{# a comment}")
# Error in glue_data(.x = NULL, ..., .sep = .sep, .envir = .envir, .open = .open,  : 
#   Unterminated comment
```

(I guess this error is for simplicity in more general expressions?)

Anyway, I thought it would be more helpful if it was clearer why it failed / how to fix it.