### PR TITLE
Ignore final empty argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # glue (development version)
 
+* `glue()` now drops the last argument if it's empty so that you can finish 
+  each line with a comma if you want (#320).
+
 * `glue_sql("{var*}")` once again generates `NULL` if var is empty.  
   This reverts #292. (#318).
 

--- a/R/glue.R
+++ b/R/glue.R
@@ -107,6 +107,12 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
 
   # Capture unevaluated arguments
   dots <- eval(substitute(alist(...)))
+
+  # Trim off last argument if its empty so you can use a trailing comma
+  n <- length(dots)
+  if (n > 0 && identical(dots[[n]], quote(expr = ))) {
+    dots <- dots[-n]
+  }
   named <- has_names(dots)
 
   # Evaluate named arguments, add results to environment
@@ -122,7 +128,7 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
       # - If `.null == NULL` then it is allowed and any such argument will be
       # silently dropped.
       # - In other cases output is treated as it was evaluated to `.null`.
-      eval(call("force", as.symbol(paste0("..", x)))) %||% .null
+      eval(as.symbol(paste0("..", x))) %||% .null
     }
   )
   unnamed_args <- drop_null(unnamed_args)

--- a/R/glue.R
+++ b/R/glue.R
@@ -119,18 +119,7 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
   env <- bind_args(dots[named], parent_env)
 
   # Concatenate unnamed arguments together
-  unnamed_args <- lapply(
-    which(!named),
-    function(x) {
-      # Any evaluation to `NULL` is replaced with `.null`:
-      # - If `.null == character()` then if any output's length is 0 the
-      # whole output should be forced to be `character(0)`.
-      # - If `.null == NULL` then it is allowed and any such argument will be
-      # silently dropped.
-      # - In other cases output is treated as it was evaluated to `.null`.
-      ...elt(x) %||% .null
-    }
-  )
+  unnamed_args <- lapply(which(!named), function(x) ...elt(x) %||% .null)
   unnamed_args <- drop_null(unnamed_args)
 
   if (length(unnamed_args) == 0) {

--- a/R/glue.R
+++ b/R/glue.R
@@ -128,7 +128,7 @@ glue_data <- function(.x, ..., .sep = "", .envir = parent.frame(),
       # - If `.null == NULL` then it is allowed and any such argument will be
       # silently dropped.
       # - In other cases output is treated as it was evaluated to `.null`.
-      eval(as.symbol(paste0("..", x))) %||% .null
+      ...elt(x) %||% .null
     }
   )
   unnamed_args <- drop_null(unnamed_args)

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -5,6 +5,10 @@ test_that("glue errors if the expression fails", {
   expect_error(glue("{NoTfOuNd}"), "object .* not found")
 })
 
+test_that("glue ignores trailing empty argument", {
+  expect_equal(glue("x", ), glue("x"))
+})
+
 test_that("glue errors if invalid format", {
   expect_error(glue("x={x"), "Expecting '}'")
 })


### PR DESCRIPTION
So you can use a trailing comma if you want. Fixes #320.