### PR TITLE
Use bleeding edge waldo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,11 +17,11 @@ Description: An implementation of interpreted string literals, inspired by
 License: MIT + file LICENSE
 URL: https://glue.tidyverse.org/, https://github.com/tidyverse/glue
 BugReports: https://github.com/tidyverse/glue/issues
-Depends: 
+Depends:
     R (>= 3.6)
 Imports:
     methods
-Suggests: 
+Suggests:
     crayon,
     DBI (>= 1.2.0),
     dplyr,
@@ -32,9 +32,9 @@ Suggests:
     RSQLite,
     testthat (>= 3.2.0),
     vctrs (>= 0.3.0),
-    waldo (>= 0.3.0),
+    waldo (>= 0.5.2),
     withr
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 ByteCompile: true
 Config/Needs/website: bench, forcats, ggbeeswarm, ggplot2, R.utils,
@@ -43,3 +43,5 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+Remotes:
+    r-lib/waldo


### PR DESCRIPTION
Fixes #331

The goal is to get a version of waldo that includes https://github.com/r-lib/waldo/pull/195, in which waldo stops importing `glue::glue()` into its `NAMESPACE`. Which allows waldo to be built from source even now that glue has adopted a more modern method of exporting `compare_proxy.glue()`.