### PR TITLE
Fix minor formatting typo

### DIFF
--- a/R/glue.R
+++ b/R/glue.R
@@ -18,7 +18,7 @@
 #'   full delimiter escapes it.
 #' @param .close \[`character(1)`: \sQuote{\\\}}]\cr The closing delimiter. Doubling the
 #'   full delimiter escapes it.
-#' @param .transformer \[`function]`\cr A function taking two arguments, `text`
+#' @param .transformer \[`function`]\cr A function taking two arguments, `text`
 #'   and `envir`, where `text` is the unparsed string inside the glue block and
 #'   `envir` is the execution environment. A `.transformer` lets you modify a
 #'   glue block before, during, or after evaluation, allowing you to create your

--- a/man/glue.Rd
+++ b/man/glue.Rd
@@ -73,7 +73,7 @@ syntactic elements), when parsing the expression string. Setting \code{.literal 
 \code{.transformer}, as is the case with \code{glue_col()}. Regard this argument
 (especially, its name) as experimental.}
 
-\item{.transformer}{[\verb{function]}\cr A function taking two arguments, \code{text}
+\item{.transformer}{[\code{function}]\cr A function taking two arguments, \code{text}
 and \code{envir}, where \code{text} is the unparsed string inside the glue block and
 \code{envir} is the execution environment. A \code{.transformer} lets you modify a
 glue block before, during, or after evaluation, allowing you to create your


### PR DESCRIPTION
While working on #335, I found a minor, formatting typo in the `glue()` docs.  I fixed it here.