### PR TITLE
Update Plausible analytics snippet

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -7,7 +7,12 @@ template:
   includes:
     in_header: |
       <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
-      <script defer data-domain="glue.tidyverse.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
+      <!-- Privacy-friendly analytics by Plausible -->
+      <script async src="https://plausible.io/js/pa-o9ySutNf0BRKwH-aSWn7-.js"></script>
+      <script>
+        window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+        plausible.init()
+      </script>
   params:
     ganalytics: UA-115082821-1
 


### PR DESCRIPTION
## Summary

- Replace the old Plausible `<script defer data-domain=...>` tag with the new async snippet that includes `plausible.init()`

## Context

Plausible has updated their recommended tracking snippet. The new format uses `async` loading with an inline init script, and no longer requires the `data-domain` attribute.
