### PR TITLE
Fix dead zero-length guard in recycle_columns()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # glue (development version)
 
+* `recycle_columns()` now correctly returns `character()` when any column has
+  zero length. The zero-length guard was previously dead code due to a misplaced
+  parenthesis (`any(lengths) == 0` instead of `any(lengths == 0)`), which made
+  `glue()` error with "Variables must be length 1" instead of producing an empty
+  result when an argument had zero length alongside others.
+
 # glue 1.8.1
 
 * The `glue` knitr engine handles multiline chunks now (#319).

--- a/R/utils.R
+++ b/R/utils.R
@@ -29,7 +29,7 @@ recycle_columns <- function(x) {
     return(x)
   }
   lengths <- vapply(x, NROW, integer(1))
-  if (any(lengths) == 0) {
+  if (any(lengths == 0)) {
     return(character())
   }
 

--- a/tests/testthat/test-glue.R
+++ b/tests/testthat/test-glue.R
@@ -154,6 +154,12 @@ test_that("error if not simple recycling", {
 test_that("recycle_columns returns if zero length input", {
   expect_identical(recycle_columns(list()), list())
   expect_identical(recycle_columns(list(character())), character())
+
+  # A zero-length column mixed with non-empty columns must also short-circuit
+  # to `character()` (previously the guard was dead code that threw an error).
+  expect_identical(recycle_columns(list(character(), "a")), character())
+  expect_identical(recycle_columns(list(character(), c("a", "b"))), character())
+  expect_identical(recycle_columns(list(c("a", "b"), character())), character())
 })
 
 test_that("glue_data evaluates in the object first, then enclosure, then parent", {


### PR DESCRIPTION
The zero-length guard in recycle_columns() was dead code: `any(lengths) == 0` collapses `lengths` to a single logical via any(), then compares that TRUE/FALSE (coerced to 1/0) to 0. As a result the branch only fired by accident for a lone zero-length column, and threw 'Variables must be length 1' whenever a zero-length column appeared alongside others.

Move the comparison inside any() to `any(lengths == 0)`, mirroring the form used one file away in R/glue.R:139 and the original tibble::recycle_columns. Add testthat coverage for the mixed zero-length case and a NEWS bullet.

Found with [ry](https://github.com/sims1253/ry)